### PR TITLE
added apiVersionForMcVersion

### DIFF
--- a/mainPlugin/src/main/java/fr/il_totore/manadrop/spigot/SpigotDescription.java
+++ b/mainPlugin/src/main/java/fr/il_totore/manadrop/spigot/SpigotDescription.java
@@ -35,6 +35,11 @@ public class SpigotDescription extends Description {
         this.apiVersion = Optional.ofNullable(apiVersion);
     }
 
+    public void apiVersionForMcVersion(String mcVersion) {
+        int version = Integer.parseInt(mcVersion.split("\\.")[1]);
+        this.apiVersion = Optional.ofNullable(mcVersion < 9 ? null : "1." + version);
+    }
+
     public enum Load {
         STARTUP, POSTWORLD
     }


### PR DESCRIPTION
I have defined the version as a variable and reuse it on multiple lines. This makes it easier to always update to the newest Minecraft version.

However, the `apiVersion` takes a different input, so I have to manually change it or write some extra logic (which I don't want to have in the `build.gradle`, especially if I need to think of legacy versions).

My current `build.gradle` looks something like this:

```
ext {
  MC_VERSION = "1.19.3"
  API_VERSION = MC_VERSION.replaceFirst("(\\d+\\.\\d+)(\\.\\d+)?", "$1")
}

spigot {
  desc {
    // Stuff in your plugin.yml
    apiVersion API_VERSION
  }
}

buildTools {
  versions MC_VERSION
  workDir = file('build/spigot')
}

processResources.finalizedBy(spigotPlugin)

dependencies {
  compileOnly MinecraftDependencyHelper.paperApi(MC_VERSION)
  compileOnly MinecraftDependencyHelper.spigot(MC_VERSION)
}
```

With this change, I am able to remove the need for the extra variable `API_VERSION` and I can just write `apiVersionForMcVersion MC_VERSION`:

```
ext {
  MC_VERSION = "1.19.3"
}

spigot {
  desc {
    // Stuff in your plugin.yml
    apiVersionForMcVersion MC_VERSION
  }
}
```