### PR TITLE
fixed unescaped regex

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,8 @@
 name: Java CI
 
-on: [push]
+on: 
+  push:
+  pull_request:
 
 jobs:
   build:

--- a/mainPlugin/src/main/java/fr/il_totore/manadrop/MinecraftDependencyHelper.java
+++ b/mainPlugin/src/main/java/fr/il_totore/manadrop/MinecraftDependencyHelper.java
@@ -23,7 +23,7 @@ public class MinecraftDependencyHelper {
     }
 
     private static String getPaperGroup(String version) {
-        int majorVersion = Integer.parseInt(version.split(".")[1]);
+        int majorVersion = Integer.parseInt(version.split("\\.")[1]);
         return majorVersion >= 16 ? "io.papermc.paper" : "com.destroystokyo.paper";
     }
 


### PR DESCRIPTION
I just copied #11, but did not notice the unescaped dot in the regex.
In addition, I made the Java CI workflow run on pull requests to avoid errors on PRs like in #16, which happened because GitHub Codespaces was down in Europe and I was using the default web editor.